### PR TITLE
Add SafeSwap - anti-rug protection hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ _A collection of hooks from Uniswap and community developers._
 - [Detox Hook](https://ethglobal.com/showcase/detox-hook-mppeg): A hook that turns MEV into LP earnings, using Pyth oracle data to detect arbitrage, capture profits, and redirect value back to liquidity providers.
 - [PureFi Verifier Hook](https://github.com/purefiprotocol/purefi-verifier-hook): A compliance-focused hook ensuring that all transactions meet specified compliance criteria.
 - [Orbital Hook](https://github.com/Dhruv-2003/ethglobal-buenos-aires-25): A Uniswap V4 Hook implementing a custom spherical AMM curve for efficient stable asset swaps.
+- [SafeSwap](https://github.com/zontak/SafeSwap): Anti-rug and anti-whale protection hook with sell rate limiting, cooldowns, progressive fees (0.3%-5%), and launch protection mode. Immutable config per pool. Live on Arbitrum One.
 
 ### From Hackathon
 


### PR DESCRIPTION
## Summary

Adding [SafeSwap](https://github.com/zontak/SafeSwap) to the community hooks list.

SafeSwap is an anti-rug and anti-whale protection hook for Uniswap V4:
- Sell rate limiting per wallet per time window
- Cooldown between sells
- Progressive fees (0.30% base, up to 5% for whale sells)
- Launch protection mode with stricter limits
- Immutable configuration per pool

Deployed and verified on Arbitrum One:
- Hook: [0x3E61d0519d598bF2dfAEf5B8Fa0256bF7e1D60c0](https://arbiscan.io/address/0x3E61d0519d598bF2dfAEf5B8Fa0256bF7e1D60c0)
- Factory: [0x3bB7a9ebc6351387E1E937772CFC3652f979cB4f](https://arbiscan.io/address/0x3bB7a9ebc6351387E1E937772CFC3652f979cB4f)

MIT licensed, open source.