### PR TITLE
Add UniCat — first v4 hook + NFT + staking miner on mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ _A collection of hooks from Uniswap and community developers._
 - [Clanker](https://www.clanker.world/): Meme coin launchpad that uses hooks for protocol fee management and MEV module integration.
 - [Ohara](https://ohara.ai/): Vibe-coded app and token launchpad that utilizes hooks.
 - [Pubhouse](https://www.pubhouse.xyz/): Prediction token market platform where user can create and trade any belief or prediction.
+- [UniCat](https://unicat.live/): The first Uniswap v4 hook combined with an ERC-721 NFT collection (888 hard cap) and staking miner on Ethereum mainnet. UniCat utilizes Uniswap v4 hook to inject swap entropy for on-chain SVG cat generation and to track LP positions, with admin power permanently renounced via lockConfig().
 
 ### From Uniswap
 


### PR DESCRIPTION
Adding UniCat to the Projects list.

## What it is

UniCat is the first Uniswap v4 hook combined with an ERC-721 NFT collection (888 hard cap) and staking miner on Ethereum mainnet.

## Hook capabilities

- \`afterAddLiquidity\`: snapshots LP position to mint a tracked LP NFT
- \`afterSwap\`: re-randomizes a global seed used as entropy for NFT generation

## Why it's notable

- Full closed-loop economy: token + NFT + mining
- Up to 51% of token supply (2,040 UNICAT) burnable via NFT mints
- Admin power permanently renounced via one-way \`lockConfig()\` (verifiable on-chain)
- All 5 contracts verified on Etherscan, MIT licensed
- Pure on-chain SVG rendering (no IPFS, no off-chain JSON)
- Hard cap supply (4,000 tokens, 888 NFTs)

## Links

- Live: https://unicat.live
- Code: https://github.com/Thanattt/unicat
- Hook contract: 0x98Fa6468C65EC0100CB92C62dC6109236C130440
- Token contract: 0x36608E64D5391bF40486EC81886308a6b8bC06a5
- NFT collection: 0xf7498e0dFa1978F1568825a69aB2F23BAc51A408