### PR TITLE
Add v4 Hook Custody Decoder to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ _Utilize these tools to boost your development process._
 - [Uniswap v4 Minimal](https://github.com/0xaaiden/uniswap-v4-minimal): Minimal subgraph for Uniswap v4.
 - [Uniswap V4 Hook Address Miner](https://v4hookaddressminer.xyz/): Fast multithreaded Uniswap V4 hook vanity address miner online tool.
 - [Uniswap Hooks Claude Code Plugin](https://github.com/Uniswap/uniswap-ai/tree/main/packages/plugins/uniswap-hooks): AI-powered, security-first assistance for creating Uniswap v4 hooks.
+- [v4 Hook Custody Decoder](https://x402.donnyautomation.com/demo/v4hooks/0x000052423c1dB6B7ff8641b85A7eEfc7B2791888): Free API that decodes any Base v4 hook address into its 14 permission bits, a custody class (PASSIVE/FLOW_CONTROL/FEE_TAKING/SWAP_CUSTODY/OPAQUE), and a three-source verification state. This can help traders and integrators see what a pool's hook is permitted to do before interacting with it.
 
 
 ## 📐 Templates


### PR DESCRIPTION
## What

Adds the v4 Hook Custody Decoder to the Tools section: a free, no-key HTTP API
that decodes a Uniswap v4 hook address on Base into:

- the 14 permission bits (decoded from the address per v4-core `Hooks.sol`)
- a custody class — PASSIVE / FLOW_CONTROL / FEE_TAKING / SWAP_CUSTODY / OPAQUE
- source-verification state via three-source consensus (Basescan, Sourcify, Blockscout)
- risk flags (swap-delta custody, EIP-1967 upgradeability, owner/blacklist/pause selectors)

## Why it fits Tools

Hook risk is invisible to token-contract scanners; this gives builders and
users a one-call capability read on any hook before interacting. It analyzes
capability only and deliberately never outputs a "safe" verdict.

## Try it

`GET https://x402.donnyautomation.com/demo/v4hooks/<hook-address>`

Example (BunniHook): https://x402.donnyautomation.com/demo/v4hooks/0x000052423c1dB6B7ff8641b85A7eEfc7B2791888
