### PR TITLE
Add GlueHook (V3) to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ _A collection of hooks from Uniswap and community developers._
 - [Clanker](https://www.clanker.world/): Meme coin launchpad that uses hooks for protocol fee management and MEV module integration.
 - [Ohara](https://ohara.ai/): Vibe-coded app and token launchpad that utilizes hooks.
 - [Pubhouse](https://www.pubhouse.xyz/): Prediction token market platform where user can create and trade any belief or prediction.
+- [GlueHook](https://gluehook.trade/): Free general-purpose hook that gives any pool a permissionless buyback pot (buys on buys, absorbs sells at the pool's exact price, burns what it buys) and a self-compounding LP with configurable fee splits. Keyless, non-upgradeable, 0% protocol fee, same address on 18+ networks.
 
 ### From Uniswap
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ _A collection of hooks from Uniswap and community developers._
 - [Clanker](https://www.clanker.world/): Meme coin launchpad that uses hooks for protocol fee management and MEV module integration.
 - [Ohara](https://ohara.ai/): Vibe-coded app and token launchpad that utilizes hooks.
 - [Pubhouse](https://www.pubhouse.xyz/): Prediction token market platform where user can create and trade any belief or prediction.
-- [GlueHook](https://gluehook.trade/): Free general-purpose hook that gives any pool a permissionless buyback pot (buys on buys, absorbs sells at the pool's exact price, burns what it buys) and a self-compounding LP with configurable fee splits. Keyless, non-upgradeable, 0% protocol fee, same address on 18+ networks.
+- [GlueHook](https://gluehook.trade/): Free general-purpose hook that gives any pool a permissionless buyback pot (buys on buys, absorbs sells at the pool's exact price, burns what it buys) and a self-compounding LP with configurable fee splits. Keyless, non-upgradeable, 0% protocol fee, same address on 13+ networks.
 
 ### From Uniswap
 


### PR DESCRIPTION
Adds GlueHook to Projects.

**Address:** GlueHook V3 `0x03D482cB3Ff339C2d29736818D0F72c66dD6A040`, the same on 14 mainnets (Ethereum, Base, Unichain, Arbitrum, Optimism, BNB, Polygon, Avalanche, X Layer, World Chain, Soneium, MegaETH, Robinhood, Arc). Earlier revisions of this PR described the V1/V2 generations; V3 replaces them as the live hook (they stay deployed for their own pools).

### Why V3 (what changed vs V1/V2)

Launch write-up with the full numbers: https://x.com/glue_fi/status/2100237021264450020

- **The pot can no longer empty itself in one transaction.** V1/V2 ran two modes — buying on buys and *defending* on sells — and the defence could spend 100% of the pot at whatever price was on screen. V3 turns the defence into a buy and puts a TWAP underneath it: the most it spends behind any one swap is `0.8·f·R` (0.8% of pool depth at a 1% pool), measured against its own ten-minute time-weighted reference. It buys in slices — hard into dips, pulling back as a rally runs ahead of the reference. Same money, more supply bought.
- **One mechanism, behind every swap, in both directions.** Behind a buyer it adds to the buy; behind a seller it buys the dip that seller just made. Traffic is the trigger and the pump runs inside the swapper's own transaction — nothing in the mempool to front-run.
- **20× to 67× harder to play.** The sandwich was already closed in V2 (a −40% loss on fees). V3 closes the other two doors: unlocking the pot costs 50% of it in fees instead of 2.5%, round-trip farming needs a bag of ~16% of pool depth instead of ~1.25%, a pushed premium `d` shrinks the pump to `f/d`, and the reference rises at most 3% a minute. Spend = `0.8 · min(f·R, f·R·bucket, s(d)·B, pot)` — derivations in the repo README ("The pump math").
- **The before-swap path is gone.** V3 runs on permission bits `0x2040` — `beforeInitialize` + `afterSwap` only. No `beforeSwap`, no return delta: the swapper's trade is the pool's plain execution and the buyback happens after it. **Quotes are exact** (vanilla V4 math, nothing to model), **swaps cannot be blocked** (every hook action is a try/catch self-call — a failing buyback is skipped, never the swap), **the surface shrank**.
- **Cheaper Glue integration.** Burns go through the Glue Protocol directly (wrapper-aware), and native programs stream live harvest data to Glue's staking/locking engines.

Site: https://gluehook.trade · Source: https://github.com/glue-finance/glueHook · Audit: https://github.com/glue-finance/glueHook/tree/main/audit · Routing allowlist: Uniswap/routing-api#1414
