### PR TITLE
Add Hook Safety Gate to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ _Utilize these tools to boost your development process._
 - [Uniswap v4 Minimal](https://github.com/0xaaiden/uniswap-v4-minimal): Minimal subgraph for Uniswap v4.
 - [Uniswap V4 Hook Address Miner](https://v4hookaddressminer.xyz/): Fast multithreaded Uniswap V4 hook vanity address miner online tool.
 - [Uniswap Hooks Claude Code Plugin](https://github.com/Uniswap/uniswap-ai/tree/main/packages/plugins/uniswap-hooks): AI-powered, security-first assistance for creating Uniswap v4 hooks.
+- [Hook Safety Gate](https://github.com/blazephoenixxyz-crypto/hook-safety-gate-v3): A default-closed admission gate for the routing side of hook safety, for routers and aggregators rather than for hook authors. It screens delta-returning hooks by address bitmask, pins each admitted hook's `EXTCODEHASH` so a proxy upgrade or redeploy stops it being routable, and puts delta hooks behind a two-step timelocked admission that reverts if the code changes between proposal and confirmation. Zero external dependencies, one line to integrate.
 
 
 ## 📐 Templates


### PR DESCRIPTION
Adds [Hook Safety Gate](https://github.com/blazephoenixxyz-crypto/hook-safety-gate-v3) to the **Tools** section.

Most of the tooling in this list serves hook *authors*. This one serves the other side: the routers and aggregators deciding which hooks they are willing to route user funds through — the same problem Uniswap's own [hooksAddressesAllowlist](https://github.com/Uniswap/routing-api/blob/main/lib/util/hooksAddressesAllowlist.ts), already linked in the Introduction, solves by hand per chain.

Three layers, one line to integrate:

- **Delta-permission screen** — `BEFORE_SWAP_RETURNS_DELTA_FLAG` / `AFTER_SWAP_RETURNS_DELTA_FLAG` are read from the hook's own address as a bitmask, so the check is constant time and the hook cannot misreport it.
- **Codehash pinning** — `EXTCODEHASH` recorded at admission and re-checked at routing, so a hook whose code changes after review (proxy upgrade, redeploy) stops being routable instead of silently continuing.
- **Timelocked delta admission** — delta hooks go through propose/confirm with a delay, and confirmation reverts if the code changed in between.

MIT, zero external dependencies, 38 tests at 768 fuzz runs. Worth stating plainly: admission is owner-controlled, so this is a tool for an integrator to express its own risk policy, not a trustless mechanism.