### PR TITLE
Add HookGuard to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ _Utilize these tools to boost your development process._
 - [Uniswap v4 Minimal](https://github.com/0xaaiden/uniswap-v4-minimal): Minimal subgraph for Uniswap v4.
 - [Uniswap V4 Hook Address Miner](https://v4hookaddressminer.xyz/): Fast multithreaded Uniswap V4 hook vanity address miner online tool.
 - [Uniswap Hooks Claude Code Plugin](https://github.com/Uniswap/uniswap-ai/tree/main/packages/plugins/uniswap-hooks): AI-powered, security-first assistance for creating Uniswap v4 hooks.
+- [HookGuard](https://github.com/chaosxcode/hookguard): Risk scanner for Uniswap v4 hooks, runnable as a GitHub Action on every pull request. Flags documented v4 risk patterns (permissionless pool attachment, missing PoolManager guards, delta-flag mismatches, unbounded dynamic fees) with inline annotations. Also publishes a [risk profile of all 486 hooks](https://chaosxcode.github.io/hookguard/) in Uniswap's official registry. Heuristic, not an audit.
 
 
 ## 📐 Templates


### PR DESCRIPTION
Adds [HookGuard](https://github.com/chaosxcode/hookguard) to the Tools section.

It's an open-source risk scanner for v4 hooks that runs as a GitHub Action on every pull request, annotating the offending lines. Eight rules, each traced to published guidance (Trail of Bits' *Building secure Uniswap v4 hooks*, Uniswap's Security Framework, OpenZeppelin, Cyfrin) or to the Bunni v2 and Cork Protocol post-mortems.

Two things that may be worth the section's readers knowing:

- It also publishes a [risk profile of all 486 hooks](https://chaosxcode.github.io/hookguard/) in Uniswap's official registry — 315 of them can move value during a swap with no audit on record. Raw JSON at `/risk.json`.
- It's measured, not just asserted: [docs/precision.md](https://github.com/chaosxcode/hookguard/blob/master/docs/precision.md) records per-rule firing rates across 170 real deployed hooks, notes that 32% come back clean, and documents a false-positive class that was found and fixed.

It's a heuristic scanner and says so — not an audit, and the README leads with that. Happy to reword or move the entry if it fits better elsewhere.