### PR TITLE
Add Midas Hooks (quote-asset substitution, decay-priced anti-snipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ _A collection of hooks from Uniswap and community developers._
 - [PureFi Verifier Hook](https://github.com/purefiprotocol/purefi-verifier-hook): A compliance-focused hook ensuring that all transactions meet specified compliance criteria.
 - [Orbital Hook](https://github.com/Dhruv-2003/ethglobal-buenos-aires-25): A Uniswap V4 Hook implementing a custom spherical AMM curve for efficient stable asset swaps.
 - [SafeSwap](https://github.com/zontak/SafeSwap): Anti-rug and anti-whale protection hook with sell rate limiting, cooldowns, progressive fees (0.3%-5%), and launch protection mode. Immutable config per pool. Live on Arbitrum One.
+- [Midas Hooks](https://github.com/thecvretoken/midas-rwa-hook): A set of hooks pairing tokens against non-ETH quote assets — PAXG (gold) and tokenized stocks — with decay-priced anti-snipe protection using a linearly decaying buy-side surcharge instead of blacklists or pause switches. Immutable constructor-capped fees, no setter, pause or blacklist, and no liquidity permissions. Live on Robinhood Chain. Unaudited.
 
 ### From Hackathon
 


### PR DESCRIPTION
Adds one entry to **From Community**.

Two patterns, both live on Robinhood Chain with verified source:

- **Quote-asset substitution** — pairs any ERC-20 against PAXG so the pool is denominated in troy ounces rather than ETH or a stablecoin.
- **Decay-priced anti-snipe** — a linearly decaying buy-side surcharge over a capped window, in place of blacklists or pause switches, so the contract holds no discretionary authority over any address.

All fee parameters are immutable and constructor-validated, with no setter, pause, or blacklist function. The hooks declare no liquidity permissions (flags `0x20CC`), so they have no callback capable of blocking an LP withdrawal.

**Unaudited** — noted in the entry. Disclosure: these are mine, and the template takes a fee share, so I benefit if they're used.

Happy to trim the entry if it runs long relative to the others.